### PR TITLE
[ZZZ] Bangboo Stat Fields and Weapon JSON Data Added

### DIFF
--- a/app/_custom/collections/_data-jsons.ts
+++ b/app/_custom/collections/_data-jsons.ts
@@ -1,0 +1,39 @@
+import type { CollectionConfig } from "payload/types";
+
+import { isStaff } from "../../db/collections/users/access";
+export const _DataJsons: CollectionConfig = {
+  slug: "_data-jsons",
+  labels: { singular: "_data-json", plural: "_data-jsons" },
+  admin: {
+    group: "Custom",
+    useAsTitle: "name",
+  },
+  access: {
+    create: isStaff, //udpate in future to allow site admins as well
+    read: () => true,
+    update: isStaff, //udpate in future to allow site admins as well
+    delete: isStaff, //udpate in future to allow site admins as well
+  },
+  fields: [
+    {
+      name: "id",
+      type: "text",
+    },
+    {
+      name: "data_key",
+      type: "text",
+    },
+    {
+      name: "name",
+      type: "text",
+    },
+    {
+      name: "json",
+      type: "json",
+    },
+    {
+      name: "checksum",
+      type: "text",
+    },
+  ],
+};

--- a/app/_custom/collections/bangboo-skills.ts
+++ b/app/_custom/collections/bangboo-skills.ts
@@ -37,6 +37,20 @@ export const BangbooSkills: CollectionConfig = {
       relationTo: "bangboos",
     },
     {
+      name: "params",
+      type: "array",
+      fields: [
+        {
+          name: "title",
+          type: "text",
+        },
+        {
+          name: "params",
+          type: "json",
+        },
+      ],
+    },
+    {
       name: "icon_path",
       type: "text",
     },

--- a/app/_custom/collections/bangboos.ts
+++ b/app/_custom/collections/bangboos.ts
@@ -45,7 +45,15 @@ export const Bangboos: CollectionConfig = {
       type: "number",
     },
     {
+      name: "hp_growth",
+      type: "number",
+    },
+    {
       name: "atk",
+      type: "number",
+    },
+    {
+      name: "atk_growth",
       type: "number",
     },
     {
@@ -53,7 +61,19 @@ export const Bangboos: CollectionConfig = {
       type: "number",
     },
     {
+      name: "def_growth",
+      type: "number",
+    },
+    {
       name: "impact",
+      type: "number",
+    },
+    {
+      name: "attribute_mastery",
+      type: "number",
+    },
+    {
+      name: "crit",
       type: "number",
     },
     {
@@ -67,6 +87,52 @@ export const Bangboos: CollectionConfig = {
       type: "relationship",
       relationTo: "bangboo-talents",
       hasMany: true,
+    },
+    {
+      name: "ascension_data",
+      type: "array",
+      fields: [
+        {
+          name: "asc",
+          type: "number",
+        },
+        {
+          name: "lv_min",
+          type: "number",
+        },
+        {
+          name: "lv_max",
+          type: "number",
+        },
+        {
+          name: "hp_adv",
+          type: "number",
+        },
+        {
+          name: "atk_adv",
+          type: "number",
+        },
+        {
+          name: "def_adv",
+          type: "number",
+        },
+        {
+          name: "materials",
+          type: "array",
+          fields: [
+            {
+              name: "material",
+              type: "relationship",
+              relationTo: "materials",
+              hasMany: false,
+            },
+            {
+              name: "qty",
+              type: "number",
+            },
+          ],
+        },
+      ],
     },
     {
       name: "icon_path",

--- a/app/_custom/collections/index.ts
+++ b/app/_custom/collections/index.ts
@@ -1,6 +1,7 @@
 import { _CharacterCamps } from "./_character-camps";
 import { _DamageElements } from "./_damage-elements";
 import { _DamageTypes } from "./_damage-types";
+import { _DataJsons } from "./_data-jsons";
 import { _DescIcons } from "./_desc-icons";
 import { _MaterialClasses } from "./_material-classes";
 import { _Rarities } from "./_rarities";
@@ -30,6 +31,7 @@ export const CustomCollections = [
   _CharacterCamps,
   _DamageElements,
   _DamageTypes,
+  _DataJsons,
   _DescIcons,
   _MaterialClasses,
   _Rarities,

--- a/app/_custom/import/importscripts.js
+++ b/app/_custom/import/importscripts.js
@@ -29,6 +29,8 @@ pnpm import_collection_data collection:bangboo-talents,filename:BangbooTalent.js
 
 # W-Engines
 pnpm import_collection_data collection:w-engines,filename:WEngine.json,idname:data_key,sync:false,overwrite:false
+# Weapon Level + Weapon Star JSON constants
+pnpm import_collection_data collection:_data-jsons,filename:_DataJsonsWLevelStar.json,idname:data_key,sync:false,overwrite:false
 
 # Disk Drives
 pnpm import_collection_data collection:disk-drive-sets,filename:DiskDriveSet.json,idname:data_key,sync:false,overwrite:false


### PR DESCRIPTION
- Bangboos and Bangboo skills now have stats per level data added + parameters.
- Added a new _data-jsons collection to store game constants for WeaponLevel and WeaponStar curves.
- Import script for _data-jsons collection added.